### PR TITLE
Update hddled_tmj33.c

### DIFF
--- a/hddled_tmj33.c
+++ b/hddled_tmj33.c
@@ -58,6 +58,7 @@
 #include <linux/fs.h>             // Header for the Linux file system support
 #include <linux/uaccess.h>        // Required for the copy to user function
 #include <linux/slab.h>           // For kmalloc/kfree
+#include <linux/io.h>             // Added because the module would not compile under Kernel 5.6 without it
 
 #ifndef HDDLED_TMJ33_VERSION
 #define HDDLED_TMJ33_VERSION "unknown"


### PR DESCRIPTION
After upgrading the Linux kernel 5.6 "make dkms" generated errors about functions such as ioremap and iounmap being implicitly declared and the module would not install. After some research I added <linux/io.h> to the list of includes.
Not tested with other kernel versions.